### PR TITLE
Refactor cow spawn system and add checks for null

### DIFF
--- a/src/main/java/com/robrit/moofluids/common/event/EntitySpawnHandler.java
+++ b/src/main/java/com/robrit/moofluids/common/event/EntitySpawnHandler.java
@@ -54,7 +54,7 @@ public class EntitySpawnHandler {
       Fluid currentEntityFluid = containableFluids[0];
       EntityTypeData entityData = EntityHelper.getEntityData(currentEntityFluid.getName());
 
-      if (!entityData.isSpawnable() || entityData.getSpawnRate() <= 0) {
+      if (entityData == null || !entityData.isSpawnable() || entityData.getSpawnRate() <= 0) {
         currentEntityFluid = null;
       }
 

--- a/src/main/java/com/robrit/moofluids/common/event/EntitySpawnHandler.java
+++ b/src/main/java/com/robrit/moofluids/common/event/EntitySpawnHandler.java
@@ -58,9 +58,10 @@ public class EntitySpawnHandler {
         currentEntityFluid = null;
       }
 
-      if (containableFluids.length > 1) {
+      int cumulatedSpawnChances = EntityHelper.getCumulatedSpawnChances();
+
+      if (containableFluids.length > 1 && cumulatedSpawnChances > 0) {
         boolean cowSpawned = false;
-        int cumulatedSpawnChances = EntityHelper.getCumulatedSpawnChances();
         int addedSpawnChances = 0;
 
         while (!cowSpawned) {

--- a/src/main/java/com/robrit/moofluids/common/util/EntityHelper.java
+++ b/src/main/java/com/robrit/moofluids/common/util/EntityHelper.java
@@ -28,10 +28,9 @@ import java.util.TreeMap;
 public class EntityHelper {
 
   private static TreeMap<String, Fluid> containableFluids = new TreeMap<String, Fluid>();
-  private static TreeMap<String, EntityTypeData>
-      entityDataMap =
-      new TreeMap<String, EntityTypeData>();
+  private static TreeMap<String, EntityTypeData> entityDataMap = new TreeMap<String, EntityTypeData>();
   private static int registeredEntityId = 0;
+  private static int cumulatedSpawnChances = 0;
 
   public static TreeMap<String, Fluid> getContainableFluids() {
     return containableFluids;
@@ -62,7 +61,15 @@ public class EntityHelper {
   }
 
   public static void setEntityData(final String fluidName, final EntityTypeData entityTypeData) {
+    // Since Treemap.put() replaces any existing entries in the Map, we need to compensate for that
+    if (hasEntityData(fluidName) && getEntityData(fluidName).isSpawnable() && getEntityData(fluidName).getSpawnRate() > 0) {
+      cumulatedSpawnChances -= getEntityData(fluidName).getSpawnRate();
+    }
+
     entityDataMap.put(fluidName, entityTypeData);
+    if (entityTypeData.isSpawnable() && entityTypeData.getSpawnRate() > 0) {
+      cumulatedSpawnChances += entityTypeData.getSpawnRate();
+    }
   }
 
   public static boolean hasEntityData(final String fluidName) {
@@ -77,6 +84,10 @@ public class EntityHelper {
     return null;
   }
 
+  public static int getCumulatedSpawnChances() {
+    return cumulatedSpawnChances;
+  }
+  
   public static int getRegisteredEntityId() {
     return registeredEntityId++;
   }


### PR DESCRIPTION
Properly implemented weighted random spawning. Previously, it would only
sample a very small subset of all possible cow fluids and just return
the first fluid entry if it didn't find a spawnable entry amongst that
set, no matter if that default fluid could be spawned or not. It now
always random rolls amongst all spawnable fluids, this covers the corner
case of very few enabled fluids amongst a large possible total set.