### PR TITLE
Improve automation support

### DIFF
--- a/src/main/java/com/robrit/moofluids/common/entity/EntityTypeData.java
+++ b/src/main/java/com/robrit/moofluids/common/entity/EntityTypeData.java
@@ -50,6 +50,7 @@ public class EntityTypeData {
 
   private int growUpTime;
   private int maxUseCooldown;
+  private int maxAutomationCooldown;
 
   private boolean damageEntities;
   private boolean damagePlayers;
@@ -160,6 +161,14 @@ public class EntityTypeData {
 
   public void setMaxUseCooldown(final int maxUseCooldown) {
     this.maxUseCooldown = maxUseCooldown;
+  }
+
+  public int getMaxAutomationCooldown() {
+    return maxAutomationCooldown;
+  }
+
+  public void setMaxAutomationCooldown(final int maxAutomationCooldown) {
+    this.maxAutomationCooldown = maxAutomationCooldown;
   }
 
   public boolean canDamageEntities() {

--- a/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
+++ b/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
@@ -115,6 +115,11 @@ public class ConfigurationHandler {
             configuration.get(entityName,
                               ConfigurationData.ENTITY_MAX_USE_COOLDOWN_KEY,
                               ConfigurationData.ENTITY_MAX_USE_COOLDOWN_DEFAULT_VALUE).getInt());
+        entityTypeData.setMaxAutomationCooldown(
+            configuration.get(entityName,
+                              ConfigurationData.ENTITY_MAX_AUTOMATION_COOLDOWN_KEY,
+                              ConfigurationData.ENTITY_MAX_AUTOMATION_COOLDOWN_DEFAULT_VALUE)
+                .getInt());
         entityTypeData.setDamagePlayers(
             configuration.get(entityName,
                               ConfigurationData.ENTITY_CAN_DAMAGE_PLAYER_KEY,

--- a/src/main/java/com/robrit/moofluids/common/ref/ConfigurationData.java
+++ b/src/main/java/com/robrit/moofluids/common/ref/ConfigurationData.java
@@ -29,6 +29,7 @@ public class ConfigurationData {
   public static final String ENTITY_FIRE_DAMAGE_AMOUNT_KEY = "Fire Damage Amount";
   public static final String ENTITY_GROW_UP_TIME_KEY = "Grow Up Time";
   public static final String ENTITY_MAX_USE_COOLDOWN_KEY = "Max Use Cooldown";
+  public static final String ENTITY_MAX_AUTOMATION_COOLDOWN_KEY = "Max Automation Cooldown";
   public static final String ENTITY_CAN_DAMAGE_PLAYER_KEY = "Can Damage Player";
   public static final String ENTITY_CAN_DAMAGE_OTHER_ENTITIES_KEY = "Can Damage Other Entities";
   public static final String EVENT_ENTITIES_ENABLED_KEY = "Event Entities Enabled";
@@ -41,6 +42,7 @@ public class ConfigurationData {
   public static final int ENTITY_FIRE_DAMAGE_AMOUNT_DEFAULT_VALUE = 0;
   public static final int ENTITY_GROW_UP_TIME_DEFAULT_VALUE = 8000; /* Quarter of a MC day */
   public static final int ENTITY_MAX_USE_COOLDOWN_DEFAULT_VALUE = 4000; /* Eighth of a MC day */
+  public static final int ENTITY_MAX_AUTOMATION_COOLDOWN_DEFAULT_VALUE = 4000;
   public static final boolean ENTITY_CAN_DAMAGE_PLAYER_DEFAULT_VALUE = true;
   public static final boolean ENTITY_CAN_DAMAGE_OTHER_ENTITIES_DEFAULT_VALUE = true;
   public static final boolean EVENT_ENTITIES_ENABLED_DEFAULT_VALUE = true;


### PR DESCRIPTION
It seems like the old MFR comparability mod will no longer be necessary for MC 1.11/1.12 . Therefore, the goal of this PR is to add two extra "features" from that mod into Moo Fluids itself.

1. The ability to set a separate cooldown time when using automated machinery.
2. Fix the client/server de-sync that occurs when a fake player interacts with a fluid cow.

Notes about the de-sync fix: The data watcher is used now as the main storage of the cooldown time since it is automatically synced to the client anytime it changes. However, we do not need to send this every tick as that would probably introduce too much packet spam. Instead, we can delay the update to every 10-20 ticks (currently set to 10) as the player should not notice if it only updates every 10-20 ticks.

I know this may not be the best way to solve this problem, so I am open to other ideas. However, I do think it is important implement some solution as de-sync can lead players to question if a machine is really milking a cow or not.