### PR TITLE
Clean up config file, implements a fluid blacklist

### DIFF
--- a/src/main/java/com/robrit/moofluids/common/MooFluids.java
+++ b/src/main/java/com/robrit/moofluids/common/MooFluids.java
@@ -61,11 +61,10 @@ public class MooFluids {
 
   @Mod.EventHandler
   public static void preInit(FMLPreInitializationEvent event) {
+    proxy.initContainableFluids();
     ConfigurationHandler.setConfigFile(event.getSuggestedConfigurationFile());
     ConfigurationHandler.init();
-    ConfigurationHandler.updateGlobalConfiguration();
-    proxy.initContainableFluids();
-    ConfigurationHandler.updateFluidConfiguration();
+    ConfigurationHandler.updateConfiguration();
     proxy.registerEntities();
     proxy.registerEntitySpawns();
     proxy.registerEventHandlers();

--- a/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
+++ b/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
@@ -86,10 +86,6 @@ public class ConfigurationHandler {
           configuration.get(entityName,
                             ConfigurationData.ENTITY_SPAWN_RATE_KEY,
                             ConfigurationData.ENTITY_SPAWN_RATE_DEFAULT_VALUE).getInt());
-      entityTypeData.setNormalDamageAmount(
-          configuration.get(entityName,
-                            ConfigurationData.ENTITY_NORMAL_DAMAGE_AMOUNT_KEY,
-                            ConfigurationData.ENTITY_NORMAL_DAMAGE_AMOUNT_DEFAULT_VALUE).getInt());
       entityTypeData.setFireDamageAmount(
           configuration.get(entityName,
                             ConfigurationData.ENTITY_FIRE_DAMAGE_AMOUNT_KEY,

--- a/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
+++ b/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
@@ -33,6 +33,8 @@ import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import java.io.File;
+import java.util.Set;
+import java.util.HashSet;
 
 public class ConfigurationHandler {
 
@@ -73,6 +75,16 @@ public class ConfigurationHandler {
   }
 
   public static void updateFluidConfiguration() {
+    boolean filterModeBlack = configuration.get(ConfigurationData.CATEGORY_FLUID_FILTER,
+                                          ConfigurationData.FILTER_TYPE_KEY,
+                                          ConfigurationData.FILTER_TYPE_DEFAULT,
+                                          ConfigurationData.FILTER_TYPE_COMMENT).getBoolean();
+    Set<String> filterList = new HashSet<String>();
+    java.util.Collections.addAll(filterList, configuration.get(ConfigurationData.CATEGORY_FLUID_FILTER,
+                                                               ConfigurationData.FILTER_LIST_KEY,
+                                                               ConfigurationData.FILTER_LIST_DEFAULT,
+                                                               ConfigurationData.FILTER_LIST_COMMENT).getStringList());
+
     for (final Fluid containableFluid : EntityHelper.getContainableFluids().values()) {
       final String containableFluidLocalizedName =
           containableFluid.getLocalizedName(new FluidStack(containableFluid, 0));
@@ -129,6 +141,13 @@ public class ConfigurationHandler {
       /* Non-configurable entity data */
       entityTypeData.setCauseFireDamage(entityTypeData.getFireDamageAmount() > 0);
       entityTypeData.setCauseNormalDamage(entityTypeData.getNormalDamageAmount() > 0);
+
+      /* Override spawning based on filter */
+      if(filterModeBlack == (filterList.contains(containableFluid.getName()) ||
+                             filterList.contains(containableFluid.getUnlocalizedName()) ||
+                             filterList.contains(containableFluidLocalizedName))) {
+        entityTypeData.setSpawnable(false);
+      }
 
       EntityHelper.setEntityData(containableFluid.getName(), entityTypeData);
     }

--- a/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
+++ b/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
@@ -33,8 +33,6 @@ import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import java.io.File;
-import java.util.Set;
-import java.util.HashSet;
 
 public class ConfigurationHandler {
 
@@ -79,11 +77,10 @@ public class ConfigurationHandler {
                                           ConfigurationData.FILTER_TYPE_KEY,
                                           ConfigurationData.FILTER_TYPE_DEFAULT,
                                           ConfigurationData.FILTER_TYPE_COMMENT).getBoolean();
-    Set<String> filterList = new HashSet<String>();
-    java.util.Collections.addAll(filterList, configuration.get(ConfigurationData.CATEGORY_FLUID_FILTER,
-                                                               ConfigurationData.FILTER_LIST_KEY,
-                                                               ConfigurationData.FILTER_LIST_DEFAULT,
-                                                               ConfigurationData.FILTER_LIST_COMMENT).getStringList());
+    String[] filterList =configuration.get(ConfigurationData.CATEGORY_FLUID_FILTER,
+                                           ConfigurationData.FILTER_LIST_KEY,
+                                           ConfigurationData.FILTER_LIST_DEFAULT,
+                                           ConfigurationData.FILTER_LIST_COMMENT).getStringList();
 
     for (final Fluid containableFluid : EntityHelper.getContainableFluids().values()) {
       final String containableFluidLocalizedName =
@@ -143,10 +140,13 @@ public class ConfigurationHandler {
       entityTypeData.setCauseNormalDamage(entityTypeData.getNormalDamageAmount() > 0);
 
       /* Override spawning based on filter */
-      if(filterModeBlack == (filterList.contains(containableFluid.getName()) ||
-                             filterList.contains(containableFluid.getUnlocalizedName()) ||
-                             filterList.contains(containableFluidLocalizedName))) {
-        entityTypeData.setSpawnable(false);
+      for (String filter: filterList) {
+        if(filterModeBlack == (containableFluid.getName().contains(filter) ||
+                               containableFluid.getUnlocalizedName().contains(filter) ||
+                               containableFluidLocalizedName.contains(filter))) {
+          entityTypeData.setSpawnable(false);
+          break;
+        }
       }
 
       EntityHelper.setEntityData(containableFluid.getName(), entityTypeData);

--- a/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
+++ b/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
@@ -39,7 +39,7 @@ public class ConfigurationHandler {
   private static File configFile;
 
   public static void init() {
-    setConfiguration(new Configuration(configFile));
+    setConfiguration(new Configuration(configFile, ConfigurationData.CONFIG_VERSION, true));
   }
 
   public static void updateConfiguration() {
@@ -52,16 +52,21 @@ public class ConfigurationHandler {
       configuration.load();
 
       /* Category comments */
-      configuration.addCustomCategoryComment(ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_KEY,
-                                             ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_COMMENT);
+      configuration.addCustomCategoryComment(ConfigurationData.CATEGORY_GLOBAL,
+                                             ConfigurationData.CATEGORY_GLOBAL_COMMENT);
 
+      configuration.addCustomCategoryComment(ConfigurationData.CATEGORY_FLUIDS,
+                                             ConfigurationData.CATEGORY_FLUIDS_COMMENT);
+
+      /* General configuration */
       ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_VALUE =
-          configuration.get(ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_KEY,
+          configuration.get(ConfigurationData.CATEGORY_GLOBAL,
                             ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_KEY,
-                            ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_DEFAULT_VALUE).getInt();
+                            ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_DEFAULT_VALUE,
+                            ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_COMMENT).getInt();
 
       ConfigurationData.EVENT_ENTITIES_ENABLED_VALUE =
-          configuration.get(ConfigurationData.EVENT_ENTITIES_ENABLED_KEY,
+          configuration.get(ConfigurationData.CATEGORY_GLOBAL,
                             ConfigurationData.EVENT_ENTITIES_ENABLED_KEY,
                             ConfigurationData.EVENT_ENTITIES_ENABLED_DEFAULT_VALUE).getBoolean();
     } catch (Exception exception) {
@@ -81,7 +86,7 @@ public class ConfigurationHandler {
       for (final Fluid containableFluid : EntityHelper.getContainableFluids().values()) {
         final String containableFluidLocalizedName =
             containableFluid.getLocalizedName(new FluidStack(containableFluid, 0));
-        final String entityName = containableFluidLocalizedName + " " + "Cow";
+        final String entityName = ConfigurationData.CATEGORY_FLUIDS + "." + containableFluidLocalizedName + " " + "Cow";
         final EntityTypeData entityTypeData = new EntityTypeData();
 
         /* Configurable entity data */

--- a/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
+++ b/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
@@ -45,12 +45,11 @@ public class ConfigurationHandler {
   public static void updateConfiguration() {
     updateGlobalConfiguration();
     updateFluidConfiguration();
+
+    if (configuration.hasChanged()) configuration.save();
   }
 
   public static void updateGlobalConfiguration() {
-    try {
-      configuration.load();
-
       /* Category comments */
       configuration.addCustomCategoryComment(ConfigurationData.CATEGORY_GLOBAL,
                                              ConfigurationData.CATEGORY_GLOBAL_COMMENT);
@@ -69,20 +68,9 @@ public class ConfigurationHandler {
           configuration.get(ConfigurationData.CATEGORY_GLOBAL,
                             ConfigurationData.EVENT_ENTITIES_ENABLED_KEY,
                             ConfigurationData.EVENT_ENTITIES_ENABLED_DEFAULT_VALUE).getBoolean();
-    } catch (Exception exception) {
-      LogHelper.error("Unable to read configuration for " + ModInformation.MOD_NAME);
-      LogHelper.error(exception);
-    } finally {
-      if (configuration.hasChanged()) {
-        configuration.save();
-      }
-    }
   }
 
   public static void updateFluidConfiguration() {
-    try {
-      configuration.load();
-
       for (final Fluid containableFluid : EntityHelper.getContainableFluids().values()) {
         final String containableFluidLocalizedName =
             containableFluid.getLocalizedName(new FluidStack(containableFluid, 0));
@@ -137,14 +125,6 @@ public class ConfigurationHandler {
 
         EntityHelper.setEntityData(containableFluid.getName(), entityTypeData);
       }
-    } catch (Exception exception) {
-      LogHelper.error("Unable to read configuration for " + ModInformation.MOD_NAME);
-      LogHelper.error(exception);
-    } finally {
-      if (configuration.hasChanged()) {
-        configuration.save();
-      }
-    }
   }
 
   public static Configuration getConfiguration() {

--- a/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
+++ b/src/main/java/com/robrit/moofluids/common/event/ConfigurationHandler.java
@@ -50,81 +50,77 @@ public class ConfigurationHandler {
   }
 
   public static void updateGlobalConfiguration() {
-      /* Category comments */
-      configuration.addCustomCategoryComment(ConfigurationData.CATEGORY_GLOBAL,
-                                             ConfigurationData.CATEGORY_GLOBAL_COMMENT);
+    /* Category comments */
+    configuration.addCustomCategoryComment(ConfigurationData.CATEGORY_GLOBAL,
+                                           ConfigurationData.CATEGORY_GLOBAL_COMMENT);
 
-      configuration.addCustomCategoryComment(ConfigurationData.CATEGORY_FLUIDS,
-                                             ConfigurationData.CATEGORY_FLUIDS_COMMENT);
+    configuration.addCustomCategoryComment(ConfigurationData.CATEGORY_FLUIDS,
+                                           ConfigurationData.CATEGORY_FLUIDS_COMMENT);
 
-      /* General configuration */
-      ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_VALUE =
-          configuration.get(ConfigurationData.CATEGORY_GLOBAL,
-                            ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_KEY,
-                            ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_DEFAULT_VALUE,
-                            ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_COMMENT).getInt();
+    /* General configuration */
+    ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_VALUE =
+        configuration.get(ConfigurationData.CATEGORY_GLOBAL,
+                          ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_KEY,
+                          ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_DEFAULT_VALUE,
+                          ConfigurationData.GLOBAL_FLUID_COW_SPAWN_RATE_COMMENT).getInt();
 
-      ConfigurationData.EVENT_ENTITIES_ENABLED_VALUE =
-          configuration.get(ConfigurationData.CATEGORY_GLOBAL,
-                            ConfigurationData.EVENT_ENTITIES_ENABLED_KEY,
-                            ConfigurationData.EVENT_ENTITIES_ENABLED_DEFAULT_VALUE).getBoolean();
+    ConfigurationData.EVENT_ENTITIES_ENABLED_VALUE =
+        configuration.get(ConfigurationData.CATEGORY_GLOBAL,
+                          ConfigurationData.EVENT_ENTITIES_ENABLED_KEY,
+                          ConfigurationData.EVENT_ENTITIES_ENABLED_DEFAULT_VALUE).getBoolean();
   }
 
   public static void updateFluidConfiguration() {
-      for (final Fluid containableFluid : EntityHelper.getContainableFluids().values()) {
-        final String containableFluidLocalizedName =
-            containableFluid.getLocalizedName(new FluidStack(containableFluid, 0));
-        final String entityName = ConfigurationData.CATEGORY_FLUIDS + "." + containableFluidLocalizedName + " " + "Cow";
-        final EntityTypeData entityTypeData = new EntityTypeData();
+    for (final Fluid containableFluid : EntityHelper.getContainableFluids().values()) {
+      final String containableFluidLocalizedName =
+          containableFluid.getLocalizedName(new FluidStack(containableFluid, 0));
+      final String entityName = ConfigurationData.CATEGORY_FLUIDS + "." + containableFluidLocalizedName + " " + "Cow";
+      final EntityTypeData entityTypeData = new EntityTypeData();
 
-        /* Configurable entity data */
-        entityTypeData.setSpawnable(
-            configuration.get(entityName,
-                              ConfigurationData.ENTITY_IS_SPAWNABLE_KEY,
-                              ConfigurationData.ENTITY_IS_SPAWNABLE_DEFAULT_VALUE).getBoolean());
-        entityTypeData.setSpawnRate(
-            configuration.get(entityName,
-                              ConfigurationData.ENTITY_SPAWN_RATE_KEY,
-                              ConfigurationData.ENTITY_SPAWN_RATE_DEFAULT_VALUE).getInt());
-        entityTypeData.setNormalDamageAmount(
-            configuration.get(entityName,
-                              ConfigurationData.ENTITY_NORMAL_DAMAGE_AMOUNT_KEY,
-                              ConfigurationData.ENTITY_NORMAL_DAMAGE_AMOUNT_DEFAULT_VALUE)
-                .getInt());
-        entityTypeData.setFireDamageAmount(
-            configuration.get(entityName,
-                              ConfigurationData.ENTITY_FIRE_DAMAGE_AMOUNT_KEY,
-                              ConfigurationData.ENTITY_FIRE_DAMAGE_AMOUNT_DEFAULT_VALUE).getInt());
-        entityTypeData.setNormalDamageAmount(
-            configuration.get(entityName,
-                              ConfigurationData.ENTITY_NORMAL_DAMAGE_AMOUNT_KEY,
-                              ConfigurationData.ENTITY_NORMAL_DAMAGE_AMOUNT_DEFAULT_VALUE)
-                .getInt());
-        entityTypeData.setGrowUpTime(
-            configuration.get(entityName,
-                              ConfigurationData.ENTITY_GROW_UP_TIME_KEY,
-                              ConfigurationData.ENTITY_GROW_UP_TIME_DEFAULT_VALUE).getInt());
-        entityTypeData.setMaxUseCooldown(
-            configuration.get(entityName,
-                              ConfigurationData.ENTITY_MAX_USE_COOLDOWN_KEY,
-                              ConfigurationData.ENTITY_MAX_USE_COOLDOWN_DEFAULT_VALUE).getInt());
-        entityTypeData.setDamagePlayers(
-            configuration.get(entityName,
-                              ConfigurationData.ENTITY_CAN_DAMAGE_PLAYER_KEY,
-                              ConfigurationData.ENTITY_CAN_DAMAGE_PLAYER_DEFAULT_VALUE)
-                .getBoolean());
-        entityTypeData.setDamageEntities(
-            configuration.get(entityName,
-                              ConfigurationData.ENTITY_CAN_DAMAGE_OTHER_ENTITIES_KEY,
-                              ConfigurationData.ENTITY_CAN_DAMAGE_OTHER_ENTITIES_DEFAULT_VALUE)
-                .getBoolean());
+      /* Configurable entity data */
+      entityTypeData.setSpawnable(
+          configuration.get(entityName,
+                            ConfigurationData.ENTITY_IS_SPAWNABLE_KEY,
+                            ConfigurationData.ENTITY_IS_SPAWNABLE_DEFAULT_VALUE).getBoolean());
+      entityTypeData.setSpawnRate(
+          configuration.get(entityName,
+                            ConfigurationData.ENTITY_SPAWN_RATE_KEY,
+                            ConfigurationData.ENTITY_SPAWN_RATE_DEFAULT_VALUE).getInt());
+      entityTypeData.setNormalDamageAmount(
+          configuration.get(entityName,
+                            ConfigurationData.ENTITY_NORMAL_DAMAGE_AMOUNT_KEY,
+                            ConfigurationData.ENTITY_NORMAL_DAMAGE_AMOUNT_DEFAULT_VALUE).getInt());
+      entityTypeData.setFireDamageAmount(
+          configuration.get(entityName,
+                            ConfigurationData.ENTITY_FIRE_DAMAGE_AMOUNT_KEY,
+                            ConfigurationData.ENTITY_FIRE_DAMAGE_AMOUNT_DEFAULT_VALUE).getInt());
+      entityTypeData.setNormalDamageAmount(
+          configuration.get(entityName,
+                            ConfigurationData.ENTITY_NORMAL_DAMAGE_AMOUNT_KEY,
+                            ConfigurationData.ENTITY_NORMAL_DAMAGE_AMOUNT_DEFAULT_VALUE).getInt());
+      entityTypeData.setGrowUpTime(
+          configuration.get(entityName,
+                            ConfigurationData.ENTITY_GROW_UP_TIME_KEY,
+                            ConfigurationData.ENTITY_GROW_UP_TIME_DEFAULT_VALUE).getInt());
+      entityTypeData.setMaxUseCooldown(
+          configuration.get(entityName,
+                            ConfigurationData.ENTITY_MAX_USE_COOLDOWN_KEY,
+                            ConfigurationData.ENTITY_MAX_USE_COOLDOWN_DEFAULT_VALUE).getInt());
+      entityTypeData.setDamagePlayers(
+          configuration.get(entityName,
+                            ConfigurationData.ENTITY_CAN_DAMAGE_PLAYER_KEY,
+                            ConfigurationData.ENTITY_CAN_DAMAGE_PLAYER_DEFAULT_VALUE).getBoolean());
+      entityTypeData.setDamageEntities(
+          configuration.get(entityName,
+                            ConfigurationData.ENTITY_CAN_DAMAGE_OTHER_ENTITIES_KEY,
+                            ConfigurationData.ENTITY_CAN_DAMAGE_OTHER_ENTITIES_DEFAULT_VALUE).getBoolean());
 
-        /* Non-configurable entity data */
-        entityTypeData.setCauseFireDamage(entityTypeData.getFireDamageAmount() > 0);
-        entityTypeData.setCauseNormalDamage(entityTypeData.getNormalDamageAmount() > 0);
+      /* Non-configurable entity data */
+      entityTypeData.setCauseFireDamage(entityTypeData.getFireDamageAmount() > 0);
+      entityTypeData.setCauseNormalDamage(entityTypeData.getNormalDamageAmount() > 0);
 
-        EntityHelper.setEntityData(containableFluid.getName(), entityTypeData);
-      }
+      EntityHelper.setEntityData(containableFluid.getName(), entityTypeData);
+    }
   }
 
   public static Configuration getConfiguration() {

--- a/src/main/java/com/robrit/moofluids/common/ref/ConfigurationData.java
+++ b/src/main/java/com/robrit/moofluids/common/ref/ConfigurationData.java
@@ -26,6 +26,7 @@ public class ConfigurationData {
   /* Configuration categories */
   public static final String CATEGORY_GLOBAL = "Global";
   public static final String CATEGORY_FLUIDS = "Individual Fluids";
+  public static final String CATEGORY_FLUID_FILTER = ConfigurationData.CATEGORY_GLOBAL + "." + "Fluid Filter";
 
   /* Configuration keys */
   public static final String GLOBAL_FLUID_COW_SPAWN_RATE_KEY = "Fluid Cow Global Spawn Rate";
@@ -38,6 +39,8 @@ public class ConfigurationData {
   public static final String ENTITY_CAN_DAMAGE_PLAYER_KEY = "Can Damage Player";
   public static final String ENTITY_CAN_DAMAGE_OTHER_ENTITIES_KEY = "Can Damage Other Entities";
   public static final String EVENT_ENTITIES_ENABLED_KEY = "Event Entities Enabled";
+  public static final String FILTER_TYPE_KEY = "Blacklist";
+  public static final String FILTER_LIST_KEY = "Fluids";
 
   /* Configuration default values */
   public static final int GLOBAL_FLUID_COW_SPAWN_RATE_DEFAULT_VALUE = 8;
@@ -50,6 +53,8 @@ public class ConfigurationData {
   public static final boolean ENTITY_CAN_DAMAGE_PLAYER_DEFAULT_VALUE = true;
   public static final boolean ENTITY_CAN_DAMAGE_OTHER_ENTITIES_DEFAULT_VALUE = true;
   public static final boolean EVENT_ENTITIES_ENABLED_DEFAULT_VALUE = true;
+  public static final boolean FILTER_TYPE_DEFAULT = true;
+  public static final String[] FILTER_LIST_DEFAULT ={};
 
   /* Configuration values */
   public static int GLOBAL_FLUID_COW_SPAWN_RATE_VALUE;
@@ -58,6 +63,12 @@ public class ConfigurationData {
   /* Configuration comments */
   public static final String CATEGORY_GLOBAL_COMMENT = "Global settings.";
   public static final String CATEGORY_FLUIDS_COMMENT = "Settings for each type of Fluid Cow.";
+  public static final String FILTER_TYPE_COMMENT =
+          "If true, cows that match this list won't spawn." + System.lineSeparator() +
+          "If false, ONLY cows that match this list will spawn." + System.lineSeparator() +
+          "This overrides the " + ENTITY_IS_SPAWNABLE_KEY + "setting on the individual cows below.";
+  public static final String FILTER_LIST_COMMENT =
+          "Fluids that should be filtered. You can use the internal name, unlocalized name, or localized name.";
 
   public static final String
       GLOBAL_FLUID_COW_SPAWN_RATE_COMMENT =

--- a/src/main/java/com/robrit/moofluids/common/ref/ConfigurationData.java
+++ b/src/main/java/com/robrit/moofluids/common/ref/ConfigurationData.java
@@ -21,6 +21,12 @@ package com.robrit.moofluids.common.ref;
 
 public class ConfigurationData {
 
+  public static final String CONFIG_VERSION = "1";
+
+  /* Configuration categories */
+  public static final String CATEGORY_GLOBAL = "Global";
+  public static final String CATEGORY_FLUIDS = "Individual Fluids";
+
   /* Configuration keys */
   public static final String GLOBAL_FLUID_COW_SPAWN_RATE_KEY = "Fluid Cow Global Spawn Rate";
   public static final String ENTITY_IS_SPAWNABLE_KEY = "Is Spawnable?";
@@ -50,6 +56,9 @@ public class ConfigurationData {
   public static boolean EVENT_ENTITIES_ENABLED_VALUE;
 
   /* Configuration comments */
+  public static final String CATEGORY_GLOBAL_COMMENT = "Global settings.";
+  public static final String CATEGORY_FLUIDS_COMMENT = "Settings for each type of Fluid Cow.";
+
   public static final String
       GLOBAL_FLUID_COW_SPAWN_RATE_COMMENT =
       "The chance of Fluid Cows spawning versus other entities. (8 is the same chance as normal Cows)";

--- a/src/main/java/com/robrit/moofluids/common/ref/ConfigurationData.java
+++ b/src/main/java/com/robrit/moofluids/common/ref/ConfigurationData.java
@@ -68,7 +68,9 @@ public class ConfigurationData {
           "If false, ONLY cows that match this list will spawn." + System.lineSeparator() +
           "This overrides the " + ENTITY_IS_SPAWNABLE_KEY + "setting on the individual cows below.";
   public static final String FILTER_LIST_COMMENT =
-          "Fluids that should be filtered. You can use the internal name, unlocalized name, or localized name.";
+          "This will compare against the internal name, unlocalized name, and localized name of a fluid." +
+           System.lineSeparator() + "If any of those contain an entry on this list, it will be filtered.";
+    ;
 
   public static final String
       GLOBAL_FLUID_COW_SPAWN_RATE_COMMENT =

--- a/src/main/java/com/robrit/moofluids/common/ref/ConfigurationData.java
+++ b/src/main/java/com/robrit/moofluids/common/ref/ConfigurationData.java
@@ -66,7 +66,7 @@ public class ConfigurationData {
   public static final String FILTER_TYPE_COMMENT =
           "If true, cows that match this list won't spawn." + System.lineSeparator() +
           "If false, ONLY cows that match this list will spawn." + System.lineSeparator() +
-          "This overrides the " + ENTITY_IS_SPAWNABLE_KEY + "setting on the individual cows below.";
+          "This overrides the \"" + ENTITY_IS_SPAWNABLE_KEY + "\" setting on the individual cows below.";
   public static final String FILTER_LIST_COMMENT =
           "This will compare against the internal name, unlocalized name, and localized name of a fluid." +
            System.lineSeparator() + "If any of those contain an entry on this list, it will be filtered.";


### PR DESCRIPTION
I've rearranged the config file to separate global settings from the settings for individual cows, because before the global settings would get mixed in the middle of all the cows due to how forge sorts config files. This also implements code to migrate from the old format to the new.

I've also implemented a fluid blacklist at the request of someone on Discord. It overrides the individual spawn setting for a fluid, and accepts partial matches against the internal name, unlocalized named, and localized name of the fluid.